### PR TITLE
优化了依赖表；扩展自定义骰面的功能，使之可以允许2d6这样的复杂掷骰式子

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
-fastapi==0.68.0
-pydantic>=1.8.0
+wheel
 uvicorn==0.15.0
 nb-cli==0.6.4
 nonebot-adapter-onebot==2.0.0b1
-nonebot2==2.0.0b1
+fastapi>=0.68.0
 openpyxl==3.0.9
 rsa==4.8
 gitpython==3.1.26
 python-docx==0.8.11
 zhconv==1.4.3
-lxml==4.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel
-uvicorn==0.15.0
+uvicorn[standard]
 nb-cli==0.6.4
 nonebot-adapter-onebot==2.0.0b1
 fastapi>=0.68.0

--- a/src/plugins/DicePP/module/common/groupconfig_command.py
+++ b/src/plugins/DicePP/module/common/groupconfig_command.py
@@ -22,7 +22,7 @@ DC_GROUPCONFIG = "group_config"
 DEFAULT_GROUP_CONFIG = {
     #基础内容
     "backroom" : False,
-    "default_dice" : 20,
+    "default_dice" : "D20",
     "mode" : "",
     #功能开关
     "roll_dnd_enable" : True,

--- a/src/plugins/DicePP/module/common/mode_command.py
+++ b/src/plugins/DicePP/module/common/mode_command.py
@@ -23,13 +23,14 @@ CFG_MODE_DEFAULT = "mode_default"
 
 MODE_FILE_PATH = "Config/mode_setting.xlsx"
 
-DEFAULT_FIELD = ['mode','default_dice', 'query_database']
+DEFAULT_FIELD = ['mode', 'default_dice', 'query_database']
 DEFAULT_TABLE = [
-    ["DND5E", "D20", "DND5E"],
-    ["PF1E", "D20", "PF1E"],
-    ["COC7", "D100", "COC7"],
-    ["NECHRONICA", "D10", "NECHRONICA"],
+    ["DND5E", "20", "DND5E"],
+    ["PF1E", "20", "PF1E"],
+    ["COC7", "100", "COC7"],
+    ["NECHRONICA", "10", "NECHRONICA"],
 ]
+
 
 @custom_user_command(readable_name="模式指令", priority=-2,
                      flag=DPP_COMMAND_FLAG_MANAGE, group_only=True
@@ -41,16 +42,21 @@ class ModeCommand(UserCommandBase):
 
     def __init__(self, bot: Bot):
         super().__init__(bot)
-        bot.loc_helper.register_loc_text(LOC_MODE_SWITCH, "已切换至{new_mode}模式（默认{dice}面骰点，查询数据库使用{database}.db（如果有））。", "。mode切换群模式指令，切换模式等于一次性修改多个群配置。\nnew_mode：切换后的模式，dice：默认骰面，database：查询使用数据库")
-        bot.loc_helper.register_loc_text(LOC_MODE_INVALID, "该模式配置有误，无法切换，请询问骰主。", "。mode切换群模式，但模式文件有问题的情况下返回")
-        bot.loc_helper.register_loc_text(LOC_MODE_NOT_EXIST, "该模式不存在！", "。mode切换群模式，但模式文件中不存在此模式时返回")
-        bot.loc_helper.register_loc_text(LOC_MODE_LIST, "以下是可用的模式列表：{modes}", "。mode模式指令查看可用模式列表\nmodes：可用模式列表")
-        bot.loc_helper.register_loc_text(LOC_MODE_LIKELY, "找到多个选项，你要找的是不是：{modes}", "。mode模式指令，模糊匹配出现多个结果\nmodes：模糊匹配结果列表")
+        bot.loc_helper.register_loc_text(LOC_MODE_SWITCH, "已切换至{new_mode}模式（默认{dice}面骰点，查询数据库使用{database}.db（如果有））。",
+                                         "。mode切换群模式指令，切换模式等于一次性修改多个群配置。\nnew_mode：切换后的模式，dice：默认骰面，database：查询使用数据库")
+        bot.loc_helper.register_loc_text(
+            LOC_MODE_INVALID, "该模式配置有误，无法切换，请询问骰主。", "。mode切换群模式，但模式文件有问题的情况下返回")
+        bot.loc_helper.register_loc_text(
+            LOC_MODE_NOT_EXIST, "该模式不存在！", "。mode切换群模式，但模式文件中不存在此模式时返回")
+        bot.loc_helper.register_loc_text(
+            LOC_MODE_LIST, "以下是可用的模式列表：{modes}", "。mode模式指令查看可用模式列表\nmodes：可用模式列表")
+        bot.loc_helper.register_loc_text(
+            LOC_MODE_LIKELY, "找到多个选项，你要找的是不是：{modes}", "。mode模式指令，模糊匹配出现多个结果\nmodes：模糊匹配结果列表")
 
         bot.cfg_helper.register_config(CFG_MODE_ENABLE, "1", "模式指令开关")
         bot.cfg_helper.register_config(CFG_MODE_DEFAULT, "DND5E2024", "群内默认模式")
 
-        self.mode_dict: Dict[str,List[str]] = {}
+        self.mode_dict: Dict[str, List[str]] = {}
         self.mode_field: List[str] = DEFAULT_FIELD
 
     def delay_init(self) -> List[str]:
@@ -68,13 +74,15 @@ class ModeCommand(UserCommandBase):
                     if str(row[0].value) == "mode":
                         self.mode_field = [str(cell.value) for cell in row]
                     else:
-                        self.mode_dict[str(row[0].value)] = [str(cell.value) for cell in row[1:]]
+                        self.mode_dict[str(row[0].value)] = [
+                            str(cell.value) for cell in row[1:]]
             else:
                 ws = wb.create_sheet(bot_id)
                 ws.append(DEFAULT_FIELD)
                 for str_row in DEFAULT_TABLE:
                     ws.append(str_row)
-                    self.mode_dict[str_row[0]] = [str_cell for str_cell in str_row[1:]]
+                    self.mode_dict[str_row[0]] = [
+                        str_cell for str_cell in str_row[1:]]
                 edited = True
             init_info.append("已载入模式文件。")
         else:
@@ -84,7 +92,8 @@ class ModeCommand(UserCommandBase):
             ws.append(DEFAULT_FIELD)
             for str_row in DEFAULT_TABLE:
                 ws.append(str_row)
-                self.mode_dict[str_row[0]] = [str_cell for str_cell in str_row[1:]]
+                self.mode_dict[str_row[0]] = [
+                    str_cell for str_cell in str_row[1:]]
             edited = True
             init_info.append("已创建模式文件。")
         if edited:
@@ -96,12 +105,14 @@ class ModeCommand(UserCommandBase):
         should_pass: bool = False
         hint: str = ""
         # 判断是否初始化，没有初始化则进行一次初始化
-        if self.bot.data_manager.get_data(DC_GROUPCONFIG,[meta.group_id,"mode"],default_val="") == "":
-            default_mode = str(self.bot.cfg_helper.get_config(CFG_MODE_DEFAULT)[0])
+        if self.bot.data_manager.get_data(DC_GROUPCONFIG, [meta.group_id, "mode"], default_val="") == "":
+            default_mode = str(
+                self.bot.cfg_helper.get_config(CFG_MODE_DEFAULT)[0])
             if default_mode != "":
-                self.switch_mode(meta.group_id,default_mode)
+                self.switch_mode(meta.group_id, default_mode)
             else:
-                self.bot.data_manager.set_data(DC_GROUPCONFIG,[meta.group_id,"mode"],"NULL")
+                self.bot.data_manager.set_data(
+                    DC_GROUPCONFIG, [meta.group_id, "mode"], "NULL")
         # 判断指令
         if not meta.group_id:
             should_proc = False
@@ -114,32 +125,38 @@ class ModeCommand(UserCommandBase):
         return should_proc, should_pass, hint
 
     def process_msg(self, msg_str: str, meta: MessageMetaData, hint: Any) -> List[BotCommandBase]:
-        port = GroupMessagePort(meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
+        port = GroupMessagePort(
+            meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
         # 判断功能开关
         try:
-            assert (int(self.bot.cfg_helper.get_config(CFG_MODE_ENABLE)[0]) != 0)
+            assert (int(self.bot.cfg_helper.get_config(
+                CFG_MODE_ENABLE)[0]) != 0)
         except AssertionError:
-            feedback = self.bot.loc_helper.format_loc_text(LOC_FUNC_DISABLE, func=self.readable_name)
+            feedback = self.bot.loc_helper.format_loc_text(
+                LOC_FUNC_DISABLE, func=self.readable_name)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
         # 判断权限
-        if meta.permission < 1: # 需要至少1级权限（群管理/骰管理）才能执行
-            feedback = self.bot.loc_helper.format_loc_text(LOC_PERMISSION_DENIED_NOTICE)
+        if meta.permission < 1:  # 需要至少1级权限（群管理/骰管理）才能执行
+            feedback = self.bot.loc_helper.format_loc_text(
+                LOC_PERMISSION_DENIED_NOTICE)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
         # 解析语句
         arg_var = hint.strip().upper()
 
         if arg_var == "DEFAULT" or arg_var == "CLEAR":
-            feedback = self.switch_mode(meta.group_id,self.bot.cfg_helper.get_config(CFG_MODE_DEFAULT)[0])
+            feedback = self.switch_mode(
+                meta.group_id, self.bot.cfg_helper.get_config(CFG_MODE_DEFAULT)[0])
         elif arg_var != "":
-            feedback = self.switch_mode(meta.group_id,arg_var)
+            feedback = self.switch_mode(meta.group_id, arg_var)
         else:
-            feedback = self.bot.loc_helper.format_loc_text(LOC_MODE_LIST, modes = "、".join(self.mode_dict.keys()))
+            feedback = self.bot.loc_helper.format_loc_text(
+                LOC_MODE_LIST, modes="、".join(self.mode_dict.keys()))
 
         return [BotSendMsgCommand(self.bot.account, feedback, [port])]
-    
+
     def switch_mode(self, group_id: str, mode: str) -> str:
         # 居然不能引用，只能在这再搭一个了
-        def update_group_config(group_id: str, setting: List[str], var:List[str]):
+        def update_group_config(group_id: str, setting: List[str], var: List[str]):
             self.bot.data_manager.delete_data(DC_GROUPCONFIG, [group_id])
             for index in range(len(setting)):
                 true_var: Any
@@ -151,16 +168,19 @@ class ModeCommand(UserCommandBase):
                     true_var = False
                 else:
                     true_var = var[index]
-                self.bot.data_manager.set_data(DC_GROUPCONFIG, [group_id,setting[index]],true_var)
-        
+                self.bot.data_manager.set_data(
+                    DC_GROUPCONFIG, [group_id, setting[index]], true_var)
+
         matched = False
         feedback = ""
         # 尝试精准匹配
         for key in self.mode_dict.keys():
             key = key.upper()
-            if key.upper() == mode: #精准匹配
-                update_group_config(group_id,self.mode_field,[key]+self.mode_dict[key])
-                feedback = self.bot.loc_helper.format_loc_text(LOC_MODE_SWITCH, new_mode = key, dice=self.mode_dict[key][0], database=self.mode_dict[key][1])
+            if key.upper() == mode:  # 精准匹配
+                update_group_config(group_id, self.mode_field, [
+                                    key]+self.mode_dict[key])
+                feedback = self.bot.loc_helper.format_loc_text(
+                    LOC_MODE_SWITCH, new_mode=key, dice=self.mode_dict[key][0], database=self.mode_dict[key][1])
                 matched = True
         # 尝试精准匹配
         if not matched:
@@ -170,21 +190,25 @@ class ModeCommand(UserCommandBase):
                 if mode in key:
                     result.append(key)
             if len(result) > 1:
-                feedback = self.bot.loc_helper.format_loc_text(LOC_MODE_LIKELY,modes="、".join(result))
+                feedback = self.bot.loc_helper.format_loc_text(
+                    LOC_MODE_LIKELY, modes="、".join(result))
             elif len(result) == 1:
                 key = result[0]
-                update_group_config(group_id,self.mode_field,[key]+self.mode_dict[key])
-                feedback = self.bot.loc_helper.format_loc_text(LOC_MODE_SWITCH, new_mode = key, dice=self.mode_dict[key][0], database=self.mode_dict[key][1])
+                update_group_config(group_id, self.mode_field, [
+                                    key]+self.mode_dict[key])
+                feedback = self.bot.loc_helper.format_loc_text(
+                    LOC_MODE_SWITCH, new_mode=key, dice=self.mode_dict[key][0], database=self.mode_dict[key][1])
                 matched = True
             else:
-                feedback = self.bot.loc_helper.format_loc_text(LOC_MODE_NOT_EXIST)+self.bot.loc_helper.format_loc_text(LOC_MODE_LIST, modes = "、".join(self.mode_dict.keys()))
-        
+                feedback = self.bot.loc_helper.format_loc_text(
+                    LOC_MODE_NOT_EXIST)+self.bot.loc_helper.format_loc_text(LOC_MODE_LIST, modes="、".join(self.mode_dict.keys()))
+
         return feedback
 
     def get_help(self, keyword: str, meta: MessageMetaData) -> str:
         if keyword == "config" or keyword == "mode":  # help后的接着的内容
             feedback: str = ".mode dnd/coc/ygo" \
-                            "套用模式设置" 
+                            "套用模式设置"
             return feedback
         return ""
 

--- a/src/plugins/DicePP/module/common/mode_command.py
+++ b/src/plugins/DicePP/module/common/mode_command.py
@@ -136,7 +136,7 @@ class ModeCommand(UserCommandBase):
                 LOC_FUNC_DISABLE, func=self.readable_name)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
         # 判断权限
-        if meta.permission < 1:  # 需要至少1级权限（群管理/骰管理）才能执行
+        if meta.permission < 0:  # 需要至少1级权限（群管理/骰管理）才能执行
             feedback = self.bot.loc_helper.format_loc_text(
                 LOC_PERMISSION_DENIED_NOTICE)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]

--- a/src/plugins/DicePP/module/common/mode_command.py
+++ b/src/plugins/DicePP/module/common/mode_command.py
@@ -136,7 +136,7 @@ class ModeCommand(UserCommandBase):
                 LOC_FUNC_DISABLE, func=self.readable_name)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
         # 判断权限
-        if meta.permission < 0:  # 需要至少1级权限（群管理/骰管理）才能执行
+        if meta.permission < 0: # 需要至少1级权限（群管理/骰管理）才能执行
             feedback = self.bot.loc_helper.format_loc_text(LOC_PERMISSION_DENIED_NOTICE)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
         # 解析语句

--- a/src/plugins/DicePP/module/common/mode_command.py
+++ b/src/plugins/DicePP/module/common/mode_command.py
@@ -25,10 +25,10 @@ MODE_FILE_PATH = "Config/mode_setting.xlsx"
 
 DEFAULT_FIELD = ['mode','default_dice', 'query_database']
 DEFAULT_TABLE = [
-    ["DND5E", "20", "DND5E"],
-    ["PF1E", "20", "PF1E"],
-    ["COC7", "100", "COC7"],
-    ["NECHRONICA", "10", "NECHRONICA"],
+    ["DND5E", "D20", "DND5E"],
+    ["PF1E", "D20", "PF1E"],
+    ["COC7", "D100", "COC7"],
+    ["NECHRONICA", "D10", "NECHRONICA"],
 ]
 
 @custom_user_command(readable_name="模式指令", priority=-2,

--- a/src/plugins/DicePP/module/common/mode_command.py
+++ b/src/plugins/DicePP/module/common/mode_command.py
@@ -137,8 +137,7 @@ class ModeCommand(UserCommandBase):
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
         # 判断权限
         if meta.permission < 0:  # 需要至少1级权限（群管理/骰管理）才能执行
-            feedback = self.bot.loc_helper.format_loc_text(
-                LOC_PERMISSION_DENIED_NOTICE)
+            feedback = self.bot.loc_helper.format_loc_text(LOC_PERMISSION_DENIED_NOTICE)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
         # 解析语句
         arg_var = hint.strip().upper()

--- a/src/plugins/DicePP/module/roll/default_dice.py
+++ b/src/plugins/DicePP/module/roll/default_dice.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from module.roll.roll_config import DICE_TYPE_DEFAULT, DICE_TYPE_MAX, DICE_NUM_MAX
 from module.roll.roll_utils import RollDiceError
-from module.roll.expression import preprocess_roll_exp, parse_roll_exp
+from module.roll.expression import preprocess_roll_exp
 
 DEFAULT_DICE_EXPR = f"D{DICE_TYPE_DEFAULT}"
 _PLACEHOLDER_PATTERN = re.compile(r'([0-9]*)D(?![0-9])')
@@ -24,8 +24,13 @@ def format_default_expr_from_input(raw_expr: str) -> str:
         return f"D{value}"
     if _PLACEHOLDER_PATTERN.search(sanitized):
         raise RollDiceError("默认骰表达式中不能包含未指定面的D")
-    # 校验表达式本身是否可解析
-    parse_roll_exp(sanitized, DICE_TYPE_DEFAULT)
+    # 基础合法性校验：仅允许掷骰表达式常见字符
+    allowed_chars = set("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ+-*/()#<>=,._")
+    if not set(sanitized).issubset(allowed_chars):
+        raise RollDiceError(f"表达式 {sanitized} 含有非法字符")
+    # 至少包含一个骰表达式或数字
+    if "D" not in sanitized and not any(ch.isdigit() for ch in sanitized):
+        raise RollDiceError(f"表达式 {sanitized} 缺少有效骰子或数值")
     return sanitized
 
 

--- a/src/plugins/DicePP/module/roll/default_dice.py
+++ b/src/plugins/DicePP/module/roll/default_dice.py
@@ -1,0 +1,109 @@
+import re
+from typing import Any
+
+from module.roll.roll_config import DICE_TYPE_DEFAULT, DICE_TYPE_MAX, DICE_NUM_MAX
+from module.roll.roll_utils import RollDiceError
+from module.roll.expression import preprocess_roll_exp, parse_roll_exp
+
+DEFAULT_DICE_EXPR = f"D{DICE_TYPE_DEFAULT}"
+_PLACEHOLDER_PATTERN = re.compile(r'([0-9]*)D(?![0-9])')
+_SIMPLE_D_PATTERN = re.compile(r'^(?:1D|D)([0-9]+)$')
+
+
+def format_default_expr_from_input(raw_expr: str) -> str:
+    """将用户输入的默认骰表达式标准化并校验."""
+    sanitized = preprocess_roll_exp(raw_expr)
+    if not sanitized:
+        raise RollDiceError("默认骰表达式不能为空")
+    if sanitized.isdigit():
+        value = int(sanitized)
+        if value < 2:
+            raise RollDiceError("默认骰面数至少为2")
+        if value > DICE_TYPE_MAX:
+            raise RollDiceError(f"默认骰面数不能超过{DICE_TYPE_MAX}")
+        return f"D{value}"
+    if _PLACEHOLDER_PATTERN.search(sanitized):
+        raise RollDiceError("默认骰表达式中不能包含未指定面的D")
+    # 校验表达式本身是否可解析
+    parse_roll_exp(sanitized, DICE_TYPE_DEFAULT)
+    return sanitized
+
+
+def format_default_expr_from_storage(raw_value: Any) -> str:
+    """读取持久化的默认骰配置并转换为合法表达式."""
+    if raw_value is None:
+        return DEFAULT_DICE_EXPR
+    if isinstance(raw_value, int):
+        value = max(2, min(int(raw_value), DICE_TYPE_MAX))
+        return f"D{value}"
+    text = str(raw_value).strip()
+    if not text:
+        return DEFAULT_DICE_EXPR
+    try:
+        return format_default_expr_from_input(text)
+    except RollDiceError:
+        return DEFAULT_DICE_EXPR
+
+
+def extract_default_type_hint(default_expr: str) -> int:
+    """对于类似D20的简单表达式提取骰面, 用于兼容旧逻辑."""
+    match = _SIMPLE_D_PATTERN.match(default_expr)
+    if match:
+        value = int(match.group(1))
+        if 2 <= value <= DICE_TYPE_MAX:
+            return value
+    return DICE_TYPE_DEFAULT
+
+
+def apply_default_expr(exp_str: str, default_expr: str) -> str:
+    """在掷骰表达式中注入默认骰表达式."""
+    expr = exp_str.strip()
+    if not expr:
+        return default_expr
+    default_wrapped = f"({default_expr})"
+    if expr[0] in "+-*/":
+        expr = f"{default_wrapped}{expr}"
+    expr = _replace_placeholder(expr, default_expr, default_wrapped)
+    return expr
+
+
+def _repeat_default(default_expr: str, count: int) -> str:
+    if count <= 0:
+        raise RollDiceError("默认骰重复次数必须大于0")
+    if count > DICE_NUM_MAX:
+        raise RollDiceError(f"默认骰重复次数不能超过{DICE_NUM_MAX}")
+    term = f"({default_expr})"
+    if count == 1:
+        return term
+    return "(" + "+".join([term] * count) + ")"
+
+
+def _replace_placeholder(expr: str, default_expr: str, default_wrapped: str) -> str:
+    result = []
+    length = len(expr)
+    index = 0
+    while index < length:
+        char = expr[index]
+        # 处理形如数字+D的占位符
+        if char.isdigit():
+            digit_start = index
+            while index < length and expr[index].isdigit():
+                index += 1
+            if index < length and expr[index] == 'D' and (index + 1 == length or not expr[index + 1].isdigit()):
+                if digit_start == 0 or not expr[digit_start - 1].isalnum():
+                    count = int(expr[digit_start:index])
+                    result.append(_repeat_default(default_expr, count))
+                    index += 1
+                    continue
+            # 回退: 不是占位符, 原样写回数字片段
+            result.append(expr[digit_start:index])
+            continue
+        # 处理裸D的占位符
+        if char == 'D' and (index + 1 == length or not expr[index + 1].isdigit()):
+            if index == 0 or not expr[index - 1].isalnum():
+                result.append(default_wrapped)
+                index += 1
+                continue
+        result.append(char)
+        index += 1
+    return "".join(result)

--- a/src/plugins/DicePP/module/roll/dice_set_command.py
+++ b/src/plugins/DicePP/module/roll/dice_set_command.py
@@ -10,6 +10,7 @@ from module.roll.default_dice import (
     format_default_expr_from_input,
     format_default_expr_from_storage,
 )
+from module.roll.roll_config import DICE_TYPE_MAX
 from module.roll.roll_utils import RollDiceError
 
 LOC_DSET_SUCCESS = "roll_default_dice_set_success"
@@ -55,17 +56,20 @@ class DiceSetCommand(UserCommandBase):
         current_expr = format_default_expr_from_storage(stored)
 
         if not arg:
-            feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_CURRENT, expr=current_expr)
+            feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_CURRENT, expr=current_expr, dice=current_expr)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
 
         try:
             new_expr = format_default_expr_from_input(arg)
         except RollDiceError as exc:
-            feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_INVALID, reason=exc.info)
+            feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_INVALID,
+                                                          reason=exc.info,
+                                                          min_face="2",
+                                                          max_face=str(DICE_TYPE_MAX))
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
 
         self.bot.data_manager.set_data(DC_GROUPCONFIG, [meta.group_id, "default_dice"], new_expr)
-        feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_SUCCESS, expr=new_expr)
+        feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_SUCCESS, expr=new_expr, dice=new_expr)
         return [BotSendMsgCommand(self.bot.account, feedback, [port])]
 
     def get_help(self, keyword: str, meta: MessageMetaData) -> str:

--- a/src/plugins/DicePP/module/roll/dice_set_command.py
+++ b/src/plugins/DicePP/module/roll/dice_set_command.py
@@ -6,13 +6,15 @@ from core.command import UserCommandBase, custom_user_command
 from core.command import BotCommandBase, BotSendMsgCommand
 from core.communication import MessageMetaData, GroupMessagePort, PrivateMessagePort
 from module.common import DC_GROUPCONFIG
-from module.roll.roll_config import DICE_TYPE_DEFAULT, DICE_TYPE_MAX
+from module.roll.default_dice import (
+    format_default_expr_from_input,
+    format_default_expr_from_storage,
+)
+from module.roll.roll_utils import RollDiceError
 
 LOC_DSET_SUCCESS = "roll_default_dice_set_success"
 LOC_DSET_INVALID = "roll_default_dice_set_invalid"
 LOC_DSET_CURRENT = "roll_default_dice_current"
-
-MIN_DICE_TYPE = 2
 
 
 @custom_user_command(readable_name="默认骰设置指令",
@@ -21,19 +23,19 @@ MIN_DICE_TYPE = 2
                      flag=DPP_COMMAND_FLAG_MANAGE,
                      permission_require=1)
 class DiceSetCommand(UserCommandBase):
-    """.dset 设置群默认骰面"""
+    """.dset 设置群默认掷骰表达式"""
 
     def __init__(self, bot: Bot):
         super().__init__(bot)
         bot.loc_helper.register_loc_text(LOC_DSET_SUCCESS,
-                                         "本群的默认掷骰面数已改为{dice}面。",
-                                         "设置群默认骰面成功时的提示")
+                                         "本群默认掷骰表达式已改为{expr}。",
+                                         "设置群默认掷骰表达式成功时的提示")
         bot.loc_helper.register_loc_text(LOC_DSET_INVALID,
-                                         "骰面必须是介于{min_face}到{max_face}之间的整数。",
-                                         "设置群默认骰面失败时的提示")
+                                         "默认掷骰表达式无效：{reason}",
+                                         "设置群默认掷骰表达式失败时的提示")
         bot.loc_helper.register_loc_text(LOC_DSET_CURRENT,
-                                         "当前默认掷骰面数为{dice}面。使用 .dset [骰面] 进行修改。",
-                                         "查询群默认骰面或缺少参数时的提示")
+                                         "当前默认掷骰表达式为{expr}。使用 .dset [表达式] 进行修改。",
+                                         "查询群默认掷骰表达式或缺少参数时的提示")
 
     def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
         should_proc = msg_str.startswith(".dset")
@@ -46,40 +48,30 @@ class DiceSetCommand(UserCommandBase):
     def process_msg(self, msg_str: str, meta: MessageMetaData, hint: Any) -> List[BotCommandBase]:
         port = GroupMessagePort(meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
         arg: str = hint if hint is not None else ""
+
+        stored = self.bot.data_manager.get_data(
+            DC_GROUPCONFIG, [meta.group_id, "default_dice"], default_val="D20"
+        )
+        current_expr = format_default_expr_from_storage(stored)
+
         if not arg:
-            current = self.bot.data_manager.get_data(
-                DC_GROUPCONFIG, [meta.group_id, "default_dice"], default_val=DICE_TYPE_DEFAULT
-            )
-            feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_CURRENT, dice=current)
+            feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_CURRENT, expr=current_expr)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
 
-        cleaned_arg = arg
-        if cleaned_arg.startswith("d"):
-            cleaned_arg = cleaned_arg[1:]
-        if cleaned_arg.endswith("d"):
-            cleaned_arg = cleaned_arg[:-1]
-        cleaned_arg = cleaned_arg.strip()
-        if not cleaned_arg.isdigit():
-            feedback = self.bot.loc_helper.format_loc_text(
-                LOC_DSET_INVALID, min_face=MIN_DICE_TYPE, max_face=DICE_TYPE_MAX
-            )
+        try:
+            new_expr = format_default_expr_from_input(arg)
+        except RollDiceError as exc:
+            feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_INVALID, reason=exc.info)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
 
-        dice_face = int(cleaned_arg)
-        if dice_face < MIN_DICE_TYPE or dice_face > DICE_TYPE_MAX:
-            feedback = self.bot.loc_helper.format_loc_text(
-                LOC_DSET_INVALID, min_face=MIN_DICE_TYPE, max_face=DICE_TYPE_MAX
-            )
-            return [BotSendMsgCommand(self.bot.account, feedback, [port])]
-
-        self.bot.data_manager.set_data(DC_GROUPCONFIG, [meta.group_id, "default_dice"], dice_face)
-        feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_SUCCESS, dice=dice_face)
+        self.bot.data_manager.set_data(DC_GROUPCONFIG, [meta.group_id, "default_dice"], new_expr)
+        feedback = self.bot.loc_helper.format_loc_text(LOC_DSET_SUCCESS, expr=new_expr)
         return [BotSendMsgCommand(self.bot.account, feedback, [port])]
 
     def get_help(self, keyword: str, meta: MessageMetaData) -> str:
         if keyword == "dset":
-            return ".dset [骰面]\n设置当前群的默认掷骰骰面"
+            return ".dset [表达式]\\n设置当前群的默认掷骰表达式"
         return ""
 
     def get_description(self) -> str:
-        return ".dset [骰面] 设置群默认骰面"
+        return ".dset [表达式] 设置群默认掷骰表达式"

--- a/src/plugins/DicePP/utils/time.py
+++ b/src/plugins/DicePP/utils/time.py
@@ -7,14 +7,27 @@ DATE_STR_FORMAT_DAY = "%Y_%m_%d"
 DATE_STR_FORMAT_WEEK = "%Y_%W"
 DATE_STR_FORMAT_MONTH = "%Y_%m"
 
+# 兼容历史数据中使用下划线或短横线分隔的时间格式
+_DATE_STR_COMPAT_FORMATS = [
+    DATE_STR_FORMAT,
+    "%Y-%m-%d %H:%M:%S",
+    "%Y_%m_%d %H:%M:%S",
+    "%Y-%m-%d_%H_%M_%S",
+    "%Y_%m_%d_%H_%M_%S",
+]
+
 
 def str_to_datetime(input_str: str) -> datetime:
     """
-    将字符串表示的时间转换为datetime格式, 字符串格式由DATE_STR_FORMAT定义, 默认是%Y/%m/%d %H:%M:%S
+    将字符串表示的时间转换为datetime格式, 支持多种历史格式兼容
     """
-    result = datetime.datetime.strptime(input_str, DATE_STR_FORMAT)
-    result = result.replace(tzinfo=china_tz)
-    return result
+    for fmt in _DATE_STR_COMPAT_FORMATS:
+        try:
+            result = datetime.datetime.strptime(input_str, fmt)
+            return result.replace(tzinfo=china_tz)
+        except ValueError:
+            continue
+    raise ValueError(f"无法解析的时间格式: {input_str}")
 
 
 def datetime_to_str(input_datetime: datetime) -> str:


### PR DESCRIPTION
 - src/plugins/DicePP/module/roll/default_dice.py:1 新增默认骰表达式工具，负责输入校验、存储格式化、提取骰面提示以及在掷骰
   指令中展开 D 占位符为完整表达式。
  - src/plugins/DicePP/module/roll/dice_set_command.py:1 重写 .dset 指令逻辑，支持设置/查询复杂默认掷骰表达式，并将错误原因通过本地化文案反馈。
  - src/plugins/DicePP/module/roll/roll_dice_command.py:239 在掷骰流程中引入默认表达式展开，覆盖空表达式、前缀运算符与 nD
    占位场景，兼容旧的面数提示。
  - src/plugins/DicePP/module/common/groupconfig_command.py:22 将群配置默认值改为字符串 D20，为复杂表达式做铺垫。
  - src/plugins/DicePP/module/common/mode_command.py:26 更新模式模板中的默认骰字段，统一采用 D20/D100/D10 字符串格式。

![PixPin_2025-09-24_13-59-33](https://github.com/user-attachments/assets/3ed6cd59-4ef9-4671-bb1b-5c53f6cf24a8)
